### PR TITLE
feat(go): add rename shortcut

### DIFF
--- a/lua/plugins/ray-x.lua
+++ b/lua/plugins/ray-x.lua
@@ -46,6 +46,12 @@ return {
         end,
         group = format_sync_grp,
       })
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = "go",
+        callback = function()
+          vim.keymap.set("n", "<leader>rn", "<cmd>GoRename<CR>", { buffer = true, desc = "Rename Go symbol" })
+        end,
+      })
     end,
     event = {"CmdlineEnter"},
     ft = { "go", "gomod" },


### PR DESCRIPTION
## Summary
- add Go-specific shortcut to rename symbol using GoRename

## Testing
- `nvim --headless -u init.lua --cmd 'set rtp+=.' +q` *(fails: extensive plugin installation required)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a2f25de0832594338a4506b60fbd